### PR TITLE
Remove debug parameter in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Usage Example
         pulses = decoder.read_pulses(pulsein)
         print("Heard", len(pulses), "Pulses:", pulses)
         try:
-            code = decoder.decode_bits(pulses, debug=False)
+            code = decoder.decode_bits(pulses)
             print("Decoded:", code)
         except adafruit_irremote.IRNECRepeatException:  # unusual short code!
             print("NEC repeat!")


### PR DESCRIPTION
debug was removed in #27 but the readme still has it which causes an exception. This will make for a nicer first experience with the library ;)

```
TypeError: unexpected keyword argument 'debug'
```